### PR TITLE
feat(features): allow creation of Message::Heartbeat::Feature enums from string keys

### DIFF
--- a/src/placeos-pulse/message/heartbeat.cr
+++ b/src/placeos-pulse/message/heartbeat.cr
@@ -21,6 +21,10 @@ module PlaceOS::Pulse
       def to_json_object_key
         to_json
       end
+
+      def self.from_json_object_key?(key)
+        self.parse(key)
+      end
     end
 
     getter feature_count : Hash(Feature, Int32)

--- a/src/placeos-pulse/message/heartbeat.cr
+++ b/src/placeos-pulse/message/heartbeat.cr
@@ -19,7 +19,7 @@ module PlaceOS::Pulse
       end
 
       def to_json_object_key
-        to_json
+        to_s.downcase
       end
 
       def self.from_json_object_key?(key)


### PR DESCRIPTION
Ran into this when updating the portal to receive serialised heartbeats:

```Error: undefined method 'from_json_object_key?' for PlaceOS::Pulse::Message::Heartbeat::Feature.class```

If there's a better way to do this just let me know 😊