### PR TITLE
fix: loosen placeos-models constraint

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -17,7 +17,7 @@ dependencies:
 
   placeos-models:
     github: placeos/models
-    version: ~> 6.0
+    version: ">= 6.0"
 
   promise:
     github: spider-gazelle/promise


### PR DESCRIPTION
**Description of the change**

Loose version constraint on models for easier updates.
We'll notice any breakage in services when updating.